### PR TITLE
chore: added service_healthy to mysql dependency

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -14,7 +14,8 @@ services:
     ports:
       - '1337:1337'
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
 
   mysql:
     container_name: huldhub_database
@@ -25,3 +26,6 @@ services:
       MYSQL_DATABASE: strapi
       MYSQL_USER: strapi
       MYSQL_PASSWORD: strapi
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      retries: 10


### PR DESCRIPTION
## Description
added service_healthy to mysql dependency on strapi container

## Considerations and implementation
- added a healthcheck config to mysql container
- strapi would then rely on mysql condition of service_healthy

### How to test
- `cd backend` to change the directory to backend
- `docker-compose rm` to clear the containers
- `docker-compose up` and observe that the `huldhub_backend` doesn't start immediately and only after `huldhub_database` 


### Screenshots

Before: strapi starts as soon as mysql container is up and running. It will fail because mysql runs but not ready.
![image](https://user-images.githubusercontent.com/8092739/137584249-1cb0d619-6c98-4231-93ec-11bc033140fa.png)
After: strapi waits after mysql container is up, running and done configuring the database:
![image](https://user-images.githubusercontent.com/8092739/137584257-b9f70ac6-c497-40a5-a3b4-e293d69c7102.png)|
