### PR TITLE
chore: added sharing /var/lib/mysql back

### DIFF
--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -25,6 +25,7 @@ services:
   mysql:
     volumes:
       - ./mysql-dump:/docker-entrypoint-initdb.d
+      - ./data:/var/lib/mysql
 
 volumes:
   modules:


### PR DESCRIPTION
## Description
Put sharing /var/lib/mysql volume to be shared with local machine back

## Considerations and implementation
Previously removed in #12. But then data would then be removed when the mysql container is rebuilt.
