### PR TITLE
feat: add links to email confirmed page

### DIFF
--- a/backend/app/config/functions/defaultData.js
+++ b/backend/app/config/functions/defaultData.js
@@ -62,7 +62,7 @@ const DEFAULT_SETTINGS = [
       allow_register: true,
       email_confirmation: true,
       email_reset_password: `http://${process.env.WEB_DOMAIN ?? "localhost:3000"}/reset-password`,
-      email_confirmation_redirection: `http://${process.env.WEB_DOMAIN ?? "localhost:3000"}/confirm-email`,
+      email_confirmation_redirection: `http://${process.env.WEB_DOMAIN ?? "localhost:3000"}/email-confirmed`,
       default_role: DEFAULT_ROLES.EMPLOYEE.type,
     },
   },

--- a/web/src/pages/EmailConfirmed.js
+++ b/web/src/pages/EmailConfirmed.js
@@ -1,11 +1,15 @@
 import React from 'react';
+import Cookies from 'js-cookie';
 
 import { Typography } from '@mui/material';
 
 import PageWrapper from '../components/PageWrapper';
 import DialogWrapper from '../components/DialogWrapper';
+import { Link } from 'react-router-dom';
 
 export default function EmailConfirmed() {
+    const jwt = Cookies.get("hub-jwt");
+
     return (
         <PageWrapper>
             <DialogWrapper>
@@ -17,9 +21,16 @@ export default function EmailConfirmed() {
                 <Typography component="p" variant="body2">
                     Your registration to Hub is now completed!
                 </Typography>
+                <br/>
                 <Typography component="p" variant="body2">
-                    You can now close this tab.
+                    Finish up by filling your profile with your information.
                 </Typography>
+                <br />
+                {jwt ?
+                    <Link to="/">Go to my profile</Link>
+                :
+                    <Link to="/login">Go to login page</Link>
+                }
             </DialogWrapper>
         </PageWrapper>
     );


### PR DESCRIPTION
## Description
If jwt is present in browser, add link to profile page
If jwt is missing, add link to login page

### How to test
Try registering twice, the other time by opening the link in email with the same browser you did the registration, and the other time by opening the link in another browser/incognito mode etc.

### Screenshots

| Before | After |
| ------ | ----- |
| ![localhost_3000_email-confirmed(iPad Pro) - old](https://user-images.githubusercontent.com/11191004/140296693-ec077711-157f-4c17-a9e7-8f2fc86fb929.png) | ![localhost_3000_email-confirmed(iPad Pro)](https://user-images.githubusercontent.com/11191004/140295483-92ca5e7b-8bd3-4dce-8d8b-cb3644c8322e.png) |
