### PR TITLE
fix: rm bio+skills and added first+last name for search

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -113,9 +113,11 @@ export const search = async (keywords, jwt) => {
       _where: {
         _or: [
           getPropertyContains("competences.name", keywords),
-          getPropertyContains("bio", keywords),
           getPropertyContains("title", keywords),
-          getPropertyContains("skills", keywords),
+          getPropertyContains("first_name", keywords),
+          getPropertyContains("last_name", keywords),
+          // getPropertyContains("bio", keywords),
+          // getPropertyContains("skills", keywords),
         ],
       },
     });


### PR DESCRIPTION
## Description
- removed bio and skills from search query
- added first_name and last_name to search query

## Considerations and implementation
- bio and skills arent shown in the frontend
- first name and last name are shown and highlighted if matched

### How to test
- Try searching for keywords in bio or skills, they wont show up
- Try searching for first name and last name, the first and last name will show
