### PR TITLE
feat: bootstrap roles permissions

### DIFF
--- a/backend/app/config/functions/bootstrap.js
+++ b/backend/app/config/functions/bootstrap.js
@@ -23,7 +23,7 @@ const profileSetup = require('./profileSetup');
 module.exports = async () => {
 
   await permissionSetup();
-  await roleSetup([DEFAULT_ROLES.ADMIN, DEFAULT_ROLES.EMPLOYEE]);
+  await roleSetup([DEFAULT_ROLES.ADMIN, DEFAULT_ROLES.EMPLOYEE, DEFAULT_ROLES.PUBLIC]);
   await defaultSettings(DEFAULT_SETTINGS);
 
   if (process.env.NODE_ENV === "development") {

--- a/backend/app/config/functions/defaultData.js
+++ b/backend/app/config/functions/defaultData.js
@@ -3,6 +3,7 @@ const DEFAULT_ROLES = {
     name: "Admin",
     descripton: "Admin user",
     type: "admin",
+    canUpload: true,
     applicationPermissions: [
       {
         controller: 'competences',
@@ -37,6 +38,7 @@ const DEFAULT_ROLES = {
     name: "Employee",
     descripton: "Employee user",
     type: "employee",
+    canUpload: true,
     applicationPermissions: [
       {
         controller: 'competences',
@@ -52,6 +54,16 @@ const DEFAULT_ROLES = {
       }
     ],
   },
+  
+  PUBLIC: {
+    name: "Public",
+    usersPermissions: [
+      {
+        controller: 'auth',
+        action: 'sendemailconfirmation',
+      },
+    ]
+  }
 };
 
 const DEFAULT_USERS = [

--- a/backend/app/config/functions/roleSetup.js
+++ b/backend/app/config/functions/roleSetup.js
@@ -67,9 +67,8 @@ const roleSetup = async (roles) => {
       await createRole(role);
       customRole = await findRoleByName(role.name);
     } 
-    await enableUploadPermissions(customRole.id);
+    if (role.canUpload) await enableUploadPermissions(customRole.id);
 
-    await enableApplicationPermissions(customRole.id, 'competence-categories', ['find']);
     if (role.applicationPermissions) {
       await Promise.all(
         role.applicationPermissions.map(async (permission) => {


### PR DESCRIPTION
## Description
- Bootstrap admin and employee permissions with correct roles
- Bootstrap public role with sendemailconfirmation

## Considerations and implementation
Roles are moved from the functions itself to the default data

### How to test
- Either remove the roles or remove all the application permissions
- Reset strapi and check the roles

### Screenshots

- Employees
![Screenshot 2021-11-30 at 17 42 27](https://user-images.githubusercontent.com/8092739/144082122-783c2fa6-531f-4842-84c7-e716956112aa.png)
- Admins
![Screenshot 2021-11-30 at 17 42 46](https://user-images.githubusercontent.com/8092739/144082345-96753447-b2dd-43ae-8a5d-01ca1ccd3b30.png)

